### PR TITLE
Add CategoryFactory, Category tests, and configure testing

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Observers\CategoryObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
@@ -11,6 +12,7 @@ use Illuminate\Support\Str;
 
 class Category extends Model
 {
+    use HasFactory;
     //
     protected $fillable =
         [

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'description' => $this->faker->word(),
+        ];
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,12 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="pgsql"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PORT" value="5432"/>
+        <env name="DB_DATABASE" value="blog_api_development_task_test"/>
+        <env name="DB_USERNAME" value="postgres"/>
+        <env name="DB_PASSWORD" value="12345678"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,7 +1,7 @@
 <?php
-
-it('returns a successful response', function () {
-    $response = $this->get('/');
-
-    $response->assertStatus(200);
-});
+//
+//it('returns a successful response', function () {
+//    $response = $this->get('/');
+//
+//    $response->assertStatus(200);
+//});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,11 @@
 |
 */
 
+use App\Services\ActivityLogService;
+use App\Services\CategoryService;
+use App\Services\PostService;
+use Illuminate\Support\Facades\Artisan;
+
 pest()->extend(Tests\TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
@@ -44,4 +49,14 @@ expect()->extend('toBeOne', function () {
 function something()
 {
     // ..
+}
+
+function activityLogService(): ActivityLogService {
+    return new ActivityLogService();
+}
+function postService(): PostService {
+    return new PostService();
+}
+function categoryService(): CategoryService {
+    return new CategoryService();
 }

--- a/tests/Unit/CategoryServiceTest.php
+++ b/tests/Unit/CategoryServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Models\Category;
+use App\Services\ActivityLogService;
+use App\Services\CategoryService;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+beforeEach(function () {
+    Artisan::call('migrate');
+});
+afterEach(function () {
+    Artisan::call('migrate:reset');
+});
+
+uses(TestCase::class);
+
+
+
+
+test('can store category', function () {
+    $data = ['name' => 'New Category'];
+
+    $category = categoryService()->store($data);
+
+    expect($category)->name->toBe('New Category')
+        ->and($category)->slug->toBe('new-category');
+    $this->assertDatabaseHas('categories', $data);
+});
+
+test('can show category', function () {
+    $category = Category::factory()->create();
+
+    $fetched = categoryService()->show($category->id);
+
+    expect($fetched->id)->toBe($category->id);
+    $this->assertDatabaseHas('categories', ['id'=>$category->id]);
+
+});
+
+test('can update category', function () {
+    $category = Category::factory()->create(['name' => 'Old']);
+
+    $updated = categoryService()->update(['name' => 'Updated'], $category->id);
+
+    expect($updated->name)->toBe('Updated');
+    $this->assertDatabaseHas('categories', ['id' => $category->id]);
+});
+
+test('can destroy category', function () {
+    $category = Category::factory()->create();
+
+    $deleted = categoryService()->destroy($category->id);
+    expect($deleted)->name->toBe($category->name);
+    $this->assertDatabaseMissing('categories', ['id' => $category->id]);
+});
+
+test('can filter categories using search', function () {
+    Category::factory()->create(['name' => 'Vue']);
+    Category::factory()->create(['name' => 'Laravel']);
+
+    $results = categoryService()->index(['search' => 'Vue']);
+
+    expect($results->count())->toBe(1)
+        ->and($results->items()[0]->name)->toBe('Vue');
+});
+
+test('can Log Activity while categories create', function () {
+    $category=Category::factory()->create();
+
+    $activityLog=activityLogService()->index([
+        "type_of_action" => 'CREATE',
+        "entity_type" => 'Category',
+        "entity_id" => $category->id,
+    ]);
+
+    expect($activityLog[0]->entity_id)->toBe($category->id);
+    $this->assertDatabaseHas('categories', ['id' => $category->id]);
+});
+
+test('can Log Activity while categories read', function () {
+    $categoryCreate = Category::factory()->create();
+    $category = categoryService()->show($categoryCreate->id);
+    $activityLog=activityLogService()->index([
+        "type_of_action" => 'READ',
+        "entity_type" => 'Category',
+        "entity_id" => $category->id,
+    ]);
+
+    expect($activityLog[0]->entity_id)->toBe($category->id);
+});
+
+test('can Log Activity while categories update', function () {
+    $category = Category::factory()->create(['name' => 'Old']);
+
+    categoryService()->update(['name' => 'test '.rand(0,100)], $category->id);
+    $activityLog=activityLogService()->index([
+        "type_of_action" => 'UPDATE',
+        "entity_type" => 'Category',
+        "entity_id" => $category->id,
+    ]);
+
+    expect($activityLog[0]->entity_id)->toBe($category->id);
+    $this->assertDatabaseHas('categories', ['id' => $category->id]);
+});
+
+test('can Log Activity while categories delete', function () {
+    $category = Category::factory()->create();
+    categoryService()->destroy($category->id);
+    $activityLog=activityLogService()->index([
+        "type_of_action" => 'DELETE',
+        "entity_type" => 'Category',
+        "entity_id" => $category->id,
+    ]);
+
+    expect($activityLog[0]->entity_id)->toBe($category->id);
+});
+

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,1 @@
 <?php
-
-test('that true is true', function () {
-    expect(true)->toBeTrue();
-});


### PR DESCRIPTION
Introduced `CategoryFactory` for generating Category model data. Added unit tests for CategoryService's CRUD operations, filtering, and activity logging. PHPUnit XML to use PostgreSQL for testing. Enhanced Pest with helper functions for service access.